### PR TITLE
Install Dir should not be quoted

### DIFF
--- a/DeployingDlg.cpp
+++ b/DeployingDlg.cpp
@@ -1006,7 +1006,7 @@ BOOL WindowsRemoteInstall( CWorkerThreadParam *pParam)
 	csTemp.FormatMessage( IDS_STATUS_LAUNCHING_SETUP, csComputer);
 	::SendMessage( hWnd, WM_SETTEXT, IDC_MESSAGE_HANDLER_LISTBOX, (LPARAM) LPCTSTR( csTemp));
 	// First create command
-	csTemp.Format( _T( "\"%s\\%s\" /S /NOSPLASH /SERVER=%s %s /D=\"%s\""),
+	csTemp.Format( _T( "\"%s\\%s\" /S /NOSPLASH /SERVER=%s %s /D=%s"),
 					csOcsAppData, 
 					GetFileName( pSettings->GetAgentSetupFile()), // remote agent setup file
 					pSettings->GetServerAddress(), // OCS Server address


### PR DESCRIPTION
The destination directory for agent installation should not be quoted as seen in NSIS documentation http://nsis.sourceforge.net/Which_command_line_parameters_can_be_used_to_configure_installers

```
/D=C:\Bla or /D=C:\Path with spaces
Set installation folder ($INSTDIR)

    Must be the last parameter on the command line and **must not contain quotes even if the path contains blank spaces.**
```

Default install dir is chosen by nsis installer if directory is quoted, which leads, on a x64 system, to an agent deployed to C:\Program Files (x86)\ whatever directory you choose (and plugins deployed to C:\Program Files\, which is the default directory chosen by the agent deploy tool)